### PR TITLE
Fix/reb 88 cleaning code

### DIFF
--- a/aux/inc/app.h
+++ b/aux/inc/app.h
@@ -13,8 +13,6 @@
 uint8_t application_init();
 uint8_t hazard_lights_blink();
 uint8_t read_input();
-uint8_t monitor_engine_block();
-uint8_t initiation_start_reb();
 uint8_t monitor_read_can();
 uint8_t monitor_tcu();
 uint8_t check_can_communication();

--- a/reb/inc/app.h
+++ b/reb/inc/app.h
@@ -13,10 +13,8 @@
 #define CAN_RESPONSE_ID 0x101
 
 uint8_t application_init();
-uint8_t hazard_lights_blink();
 uint8_t read_input();
 uint8_t monitor_read_can();
-uint8_t monitor_tcu();
 uint8_t start_reb();
 uint8_t cancel_reb();
 uint8_t countdown_reb();

--- a/reb/inc/ecu_reb.h
+++ b/reb/inc/ecu_reb.h
@@ -11,7 +11,6 @@
 #define IPC_REB_START 1
 #define IPC_REB_CANCEL 2
 
-uint8_t can_send_hazard_light(uint8_t status);
 uint8_t handle_tcu_can(unsigned char data[]);
 uint8_t reb_can_send_ecu(uint8_t status);
 uint8_t reb_can_send_ipc(uint8_t status);

--- a/reb/src/app.c
+++ b/reb/src/app.c
@@ -2,9 +2,9 @@
 #include <ecu.h>
 #include <ecu_reb.h>
 #include <mcal.h>
-#include <time.h>
 #include <pins.h>
 #include <stdio.h>
+#include <time.h>
 
 uint8_t flag_reb_canceled = REB_RUNNING;
 
@@ -72,7 +72,8 @@ uint8_t monitor_read_can()
             if (frame.can_id == AUX_COM_ID && frame.data[0] == AUX_COM_SIG)
             {
                 // Check REB x AUX Communication and send response as ok
-                struct can_frame response = {.can_id = REB_COM_ID, .can_dlc = 1, .data = {REB_COM_SIG}};
+                struct can_frame response = {
+                    .can_id = REB_COM_ID, .can_dlc = 1, .data = {REB_COM_SIG}};
 
                 if (can_send_vcan0(&response) == FAIL)
                 {
@@ -97,8 +98,8 @@ uint8_t monitor_read_can()
 uint8_t cancel_reb()
 {
     flag_reb_canceled = REB_CANCELED;
-    //printf("Valor do REB_CANCELED = %d\n", flag_reb_canceled);
-    // Send by CAN to IPC the Caceled REB status
+    // printf("Valor do REB_CANCELED = %d\n", flag_reb_canceled);
+    //  Send by CAN to IPC the Caceled REB status
     if (reb_can_send_ipc(IPC_REB_CANCEL) == FAIL)
     {
         show_error("cancel_reb.reb_can_send_ipc FAIL\n");
@@ -112,7 +113,6 @@ uint8_t cancel_reb()
         return FAIL;
     }
 
-    show_error("REB deactivate with success.\n");
     return SUCCESS;
 }
 
@@ -128,7 +128,6 @@ uint8_t start_reb()
     // Reset flag when start reb
     flag_reb_canceled = REB_RUNNING;
 
-
     show_log("Start REB counting and send can to IPC");
     // send by CAN to IPC the start REB counting
     if (reb_can_send_ipc(IPC_REB_START) == FAIL)
@@ -138,13 +137,13 @@ uint8_t start_reb()
     }
 
     // TODO create another thread? probably a mutex?
-       //printf("Reb canceled entrou %d==%d\n", REB_CANCELED, flag_reb_canceled);
+    // printf("Reb canceled entrou %d==%d\n", REB_CANCELED, flag_reb_canceled);
 
-        if (flag_reb_canceled == REB_CANCELED)
-        {
-            show_error("REB canceled before timeout\n");
-            return SUCCESS;
-        }
+    if (flag_reb_canceled == REB_CANCELED)
+    {
+        show_error("REB canceled before timeout\n");
+        return SUCCESS;
+    }
 
     return SUCCESS;
 }
@@ -155,7 +154,7 @@ uint8_t start_reb()
  * @requir{SwHLR_F_12}
  * @requir{SwHLR_F_14}
  */
- uint8_t countdown_reb(void)
+uint8_t countdown_reb(void)
 {
     while (1)
     {
@@ -172,14 +171,13 @@ uint8_t start_reb()
         {
             clock_gettime(CLOCK_MONOTONIC, &current_time);
 
-            elapsed_time =
-                (current_time.tv_sec - start_time.tv_sec) +
-                ((double)(current_time.tv_nsec - start_time.tv_nsec) / 1e9);
+            elapsed_time = (current_time.tv_sec - start_time.tv_sec) +
+                           ((double)(current_time.tv_nsec - start_time.tv_nsec) / 1e9);
 
             if (elapsed_time >= REB_TIMEOUT)
             {
-                reb_can_send_ecu(ECU_REB_START);      
-                set_pin_status(S_OFF, REB_COUNTDOWN_PIN);   
+                reb_can_send_ecu(ECU_REB_START);
+                set_pin_status(S_OFF, REB_COUNTDOWN_PIN);
             }
 
             // Verify the status of the pin again

--- a/reb/src/ecu_reb.c
+++ b/reb/src/ecu_reb.c
@@ -6,35 +6,6 @@
 #include <unistd.h>
 
 /**
- *  @brief Send a CAN Message to turn ON or OF the hazard light
- *
- *  @param status 0 to send frame data 0x01(ON);  2 to send frame data 0x02(OFF).
- *  @return SUCCESS(0), FAIL(1)
- *  @requir{SwHLR_F_10}
- */
-uint8_t can_send_hazard_light(uint8_t status)
-{
-    struct can_frame frame = {.can_id = 0x400, .can_dlc = 8, .data = {0}};
-
-    if (status == 0)
-    {
-        // Send TURN ON signal
-        frame.data[0] = 0x01;
-    }
-    else
-    {
-        // Send TURN OFF signal
-        frame.data[0] = 0x02;
-    }
-
-    if (can_send_vcan0(&frame) == FAIL)
-    {
-        return FAIL;
-    }
-    return SUCCESS;
-}
-
-/**
  *  @brief Handle TCU signal received from can
  *
  *  @param data Pointer to frame message receive from TCU Can.
@@ -50,7 +21,6 @@ uint8_t handle_tcu_can(unsigned char *data)
     {
         // Deactivate pin for countdown
         set_pin_status(S_OFF, REB_COUNTDOWN_PIN);
-        show_error("Deactivating REB.\n");
         if (cancel_reb() == FAIL)
         {
             show_error("tcu_can.cancel_reb FAIL\n");

--- a/test/reb/reb_ecu/src/test_reb_ecu.c
+++ b/test/reb/reb_ecu/src/test_reb_ecu.c
@@ -16,7 +16,6 @@
  * Requirements covered:
  * - SwHLR_F_3 (handle_tcu_can)
  * - SwHLR_F_8 (reb_can_send_ipc)
- * - SwHLR_F_10 (can_send_hazard_light)
  * - SwHLR_F_12 (reb_can_send_ecu)
  */
 
@@ -95,38 +94,6 @@ TEST(reb_ecu, reb_can_send_ecu_status_ECU_REB_CANCEL)
 {
     reb_ecu_id = 2;
     int result_ok = reb_can_send_ecu(reb_ecu_id);
-    TEST_ASSERT_EQUAL(0, result_ok);
-}
-
-/**
- * @brief Tests can_send_hazard_light() with status = 0 (TURN_ON).
- *
- * Scenario:
- *  - reb_ecu_harzard_status = 0 (turn hazard light ON)
- * Expected:
- *  - Return SUCCESS (0).
- * @requir{SwHLR_F_10}
- */
-TEST(reb_ecu, reb_can_send_harzard_status_TURN_ON)
-{
-    uint8_t reb_ecu_harzard_status = 0;
-    int result_ok = can_send_hazard_light(reb_ecu_harzard_status);
-    TEST_ASSERT_EQUAL(0, result_ok);
-}
-
-/**
- * @brief Tests can_send_hazard_light() with status = 2 (TURN_OFF).
- *
- * Scenario:
- *  - reb_ecu_harzard_status = 2 (turn hazard light OFF)
- * Expected:
- *  - Return SUCCESS (0).
- * @requir{SwHLR_F_10}
- */
-TEST(reb_ecu, reb_can_send_harzard_status_TURN_OFF)
-{
-    uint8_t reb_ecu_harzard_status = 2;
-    int result_ok = can_send_hazard_light(reb_ecu_harzard_status);
     TEST_ASSERT_EQUAL(0, result_ok);
 }
 
@@ -235,22 +202,5 @@ TEST(reb_ecu, reb_can_send_ipc_CAN_SEND_VCAN_FAIL)
     set_mock_return_values(0, 0, -1, 0, 0, 0);
     reb_ipc_id = 2;
     int result_ok = reb_can_send_ipc(reb_ipc_id);
-    TEST_ASSERT_EQUAL(1, result_ok);
-}
-
-/**
- * @brief Tests can_send_hazard_light() with can_send_vcan0() failure.
- *
- * Scenario:
- *  - reb_ecu_harzard_status = 2
- *  - We force can_send_vcan0() to fail via mocks (returning -1).
- * Expected:
- *  - Return FAIL (1).
- */
-TEST(reb_ecu, reb_can_send_harzard_CAN_SEND_VCAN_FAIL)
-{
-    set_mock_return_values(0, 0, -1, 0, 0, 0);
-    uint8_t reb_ecu_harzard_status = 2;
-    int result_ok = can_send_hazard_light(reb_ecu_id);
     TEST_ASSERT_EQUAL(1, result_ok);
 }

--- a/test/reb/reb_ecu/src/test_runners/reb_ecu_runner.c
+++ b/test/reb/reb_ecu/src/test_runners/reb_ecu_runner.c
@@ -14,13 +14,10 @@ TEST_GROUP_RUNNER(reb_ecu)
     RUN_TEST_CASE(reb_ecu, reb_can_send_ipc_status_IPC_REB_CANCEL);
     RUN_TEST_CASE(reb_ecu, reb_can_send_ecu_status_ECU_REB_START);
     RUN_TEST_CASE(reb_ecu, reb_can_send_ecu_status_ECU_REB_CANCEL);
-    RUN_TEST_CASE(reb_ecu, reb_can_send_harzard_status_TURN_ON);
-    RUN_TEST_CASE(reb_ecu, reb_can_send_harzard_status_TURN_OFF);
     RUN_TEST_CASE(reb_ecu, reb_handle_tcu_can_CANCEL_REB);
     RUN_TEST_CASE(reb_ecu, reb_handle_tcu_can_START_REB);
     RUN_TEST_CASE(reb_ecu, reb_handle_tcu_can_CANCEL_REB_FAIL);
     RUN_TEST_CASE(reb_ecu, reb_handle_tcu_can_START_REB_FAIL);
     RUN_TEST_CASE(reb_ecu, reb_can_send_ecu_CAN_SEND_VCAN_FAIL);
     RUN_TEST_CASE(reb_ecu, reb_can_send_ipc_CAN_SEND_VCAN_FAIL);
-    RUN_TEST_CASE(reb_ecu, reb_can_send_harzard_CAN_SEND_VCAN_FAIL);
 }


### PR DESCRIPTION
Remoção de includes que não estão sendo utilizados nos arquivos REB e AUX.
Limpeza de código, removendo funções que não estão sendo utilizadas.
Removendo chamadas de função show_error em lugar indevido