### PR TITLE
doc:inserted mcdc in make cov report

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -18,9 +18,9 @@ $(shell mkdir -p cov/main)
 cov:
 	$(MAKE) clean
 	$(MAKE) all
-	@lcov -o cov/main/main_coverage.info -c -d . --ignore-errors=mismatch --rc branch_coverage=1
-	@lcov -o cov/main/main_coverage.info --ignore-errors=mismatch --rc branch_coverage=1 -r cov/main/main_coverage.info /test/
-	@genhtml cov/main/main_coverage.info -o cov/out --branch-coverage
+	@lcov -o cov/main/main_coverage.info -c -d . --ignore-errors=mismatch --rc branch_coverage=1 --ignore-errors=inconsistent --rc mcdc_coverage=1 
+	@lcov -o cov/main/main_coverage.info --ignore-errors=mismatch --rc branch_coverage=1 --ignore-errors=inconsistent --rc mcdc_coverage=1 -r cov/main/main_coverage.info /test/
+	@genhtml cov/main/main_coverage.info -o cov/out --branch-coverage --mcdc-coverage
 	@xdg-open cov/out/index.html
 
 clean:

--- a/test/aux/Makefile
+++ b/test/aux/Makefile
@@ -4,6 +4,7 @@ CC = gcc
 CFLAGS = -g
 CFLAGS += -coverage
 CFLAGS += -fprofile-update=atomic
+CFLAGS += -fcondition-coverage
 
 
 INCLUDES = -I../unity/inc -I../../bsw/inc -I../../aux/inc -I./mocks

--- a/test/reb/bsw_ecu/Makefile
+++ b/test/reb/bsw_ecu/Makefile
@@ -1,7 +1,7 @@
 .PHONY: clean reb aux all
 
 CC = gcc
-CFLAGS += -coverage
+CFLAGS += -coverage -fcondition-coverage
 
 INCLUDES = -I../../unity/inc -I../../../bsw/inc -I../mocks
 

--- a/test/reb/bsw_mcal/makefile
+++ b/test/reb/bsw_mcal/makefile
@@ -1,7 +1,7 @@
 .PHONY: clean reb aux all
 
 CC = gcc
-CFLAGS += -coverage
+CFLAGS += -coverage -fcondition-coverage
 
 INCLUDES = -I../../unity/inc -I../../../bsw/inc -I../mocks
 

--- a/test/reb/reb_app/Makefile
+++ b/test/reb/reb_app/Makefile
@@ -1,7 +1,8 @@
 .PHONY: clean reb aux all
 
 CC = gcc
-CFLAGS += -coverage
+CFLAGS += -coverage -fcondition-coverage
+
 
 INCLUDES = -I../../unity/inc -I../../../bsw/inc -I../mocks -I../../../reb/inc
 

--- a/test/reb/reb_ecu/Makefile
+++ b/test/reb/reb_ecu/Makefile
@@ -1,7 +1,7 @@
 .PHONY: clean reb aux all
 
 CC = gcc
-CFLAGS += -coverage
+CFLAGS += -coverage -fcondition-coverage
 
 INCLUDES = -I../../unity/inc -I../../../bsw/inc -I../mocks -I../../../reb/inc
 


### PR DESCRIPTION
Incluido mc/dc no report do MAKE COV.

Para a geração do mcdc é necessário utilizar a versão do gcc acima do 14.2