### PR TITLE
feat:fixed makefile to include dtc_logger.c file

### DIFF
--- a/test/aux/Makefile
+++ b/test/aux/Makefile
@@ -21,7 +21,7 @@ UNITY_DIR = ../unity/src
 MOCK_DIR = ./mocks
 
 
-BSW_FILES = $(BSW_DIR)/mcal.c $(BSW_DIR)/ecu.c  
+BSW_FILES = $(BSW_DIR)/mcal.c $(BSW_DIR)/ecu.c  $(BSW_DIR)/dtc_logger.c
 
 MOCK_FILES = $(wildcard $(MOCK_DIR)/*c)
 

--- a/test/reb/Makefile
+++ b/test/reb/Makefile
@@ -16,7 +16,7 @@ TARGET_REB = $(BIN_DIR)/run_test_reb
 UNITY_DIR = ../unity/src
 
 
-BSW_FILES = $(BSW_DIR)/mcal.c $(BSW_DIR)/ecu.c  
+BSW_FILES = $(BSW_DIR)/mcal.c $(BSW_DIR)/ecu.c  $(BSW_DIR)/dtc_logger.c
 
 REB_FILES = $(REB_DIR)/ecu_reb.c $(REB_DIR)/app.c
 


### PR DESCRIPTION
Arrumando makefile para incluir o dtc_logger.c na compilação de testes.