### PR TITLE
Added possibility to read Misra C with a rule file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ misra-aux:
 	@for file in $(AUX_SRC_FILES); do \
 		FILENAME=$$(basename $$file); \
 		OUTPUT_FILE=$(AUX_REPORT_DIR)/$$(basename $$FILENAME .c)_misra.txt; \
-		cppcheck --enable=all --addon=misra --library=posix --force \
+		cppcheck --enable=style --addon=./misra.json --library=posix --force \
 			-I $(AUXINCFOLDER) -I $(BSWINCFOLDER) \
 			$$file \
 			--output-file=$$OUTPUT_FILE; \
@@ -95,7 +95,7 @@ misra-bsw:
 	@for file in $(BSW_SRC_FILES); do \
 		FILENAME=$$(basename $$file); \
 		OUTPUT_FILE=$(BSW_REPORT_DIR)/$$(basename $$FILENAME .c)_misra.txt; \
-		cppcheck --enable=all --addon=misra --library=posix --force \
+		cppcheck --enable=style --addon=./misra.json --library=posix --force \
 			-I $(BSWINCFOLDER) \
 			$$file \
 			--output-file=$$OUTPUT_FILE; \
@@ -107,7 +107,7 @@ misra-reb:
 	@for file in $(REB_SRC_FILES); do \
 		FILENAME=$$(basename $$file); \
 		OUTPUT_FILE=$(REB_REPORT_DIR)/$$(basename $$FILENAME .c)_misra.txt; \
-		cppcheck --enable=all --addon=misra --library=posix --force \
+		cppcheck --enable=style  --addon=./misra.json --library=posix --force \
 			-I $(REBINCFOLDER) -I $(BSWINCFOLDER) \
 			$$file \
 			--output-file=$$OUTPUT_FILE; \

--- a/misra.json
+++ b/misra.json
@@ -1,0 +1,6 @@
+{
+    "script": "misra.py",
+    "args": [
+      "--rule-texts=misra_c_2012.txt"
+    ]
+  }


### PR DESCRIPTION
If you add a description file named misra_c_2012.txt with all the rules, then you will have a translated output for Misra C violations.