### PR TITLE
doc:inserted missing comments on test reb/app. Inserted requirements …

### DIFF
--- a/aux/src/app.c
+++ b/aux/src/app.c
@@ -201,8 +201,8 @@ uint8_t monitor_tcu(void)
 /**
  * @brief Check communication CAN between REB e AUX modules sending a frame and receving a response.
  * @return SUCCESS(0); FAIL(1).
- * @requir {SwHLR_F_13}
- * @requir {SwHLR_F_15}
+ * @requir{SwHLR_F_13}
+ * @requir{SwHLR_F_15}
  */
 uint8_t check_can_communication(void)
 {

--- a/reb/src/app.c
+++ b/reb/src/app.c
@@ -56,8 +56,11 @@ uint8_t read_input(void)
 /**
  * @brief Handle messages received from CAN BUS
  * @return SUCCESS(0); FAIL(1).
+ * @requir{SwHLR_F_1}
+ * @requir{SwHLR_F_3}
  * @requir{SwHLR_F_6}
  * @requir{SwHLR_F_10}
+ * @requir{SwHLR_F_13}
  * @requir{SwHLR_F_15}
  */
 uint8_t monitor_read_can(void)
@@ -110,7 +113,7 @@ uint8_t cancel_reb(void)
     if (reb_can_send_ipc(IPC_REB_CANCEL) == FAIL)
     {
         REPORT_ERROR("cancel_reb.reb_can_send_ipc FAIL\n", DTC_REB_CAN_IPC_CANCEL_FAIL);
-        status =  FAIL;
+        status = FAIL;
     }
 
     if (status == SUCCESS)
@@ -119,7 +122,7 @@ uint8_t cancel_reb(void)
         if (reb_can_send_ecu(ECU_REB_CANCEL) == FAIL)
         {
             REPORT_ERROR("cancel_reb.reb_can_send_ecu FAIL\n", DTC_REB_CAN_ECU_CANCEL_FAIL);
-            status =  FAIL;
+            status = FAIL;
         }
     }
     return status;
@@ -130,6 +133,8 @@ uint8_t cancel_reb(void)
  * @return SUCCESS(0); FAIL(1).
  * @requir{SwHLR_F_8}
  * @requir{SwHLR_F_12}
+ * @requir{SwHLR_F_14}
+ * @requir{SwHLR_F_2}
  */
 uint8_t start_reb(void)
 {
@@ -162,6 +167,7 @@ uint8_t start_reb(void)
  * @requir{SysHLR_3}
  * @requir{SwHLR_F_12}
  * @requir{SwHLR_F_14}
+ * @requir{SwHLR_F_1}
  */
 uint8_t countdown_reb(void)
 {

--- a/reb/src/ecu_reb.c
+++ b/reb/src/ecu_reb.c
@@ -51,6 +51,9 @@ uint8_t handle_tcu_can(const unsigned char *data)
  *  @param status 1 to send frame data 0x01(Block);  2 to send frame data 0x02(Unblock).
  *  @return SUCCESS(0), FAIL(1)
  *  @requir{SwHLR_F_12}
+ *  @requir{SwHLR_F_10}
+ *  @requir{SwHLR_F_2}
+ *  @requir{SwHLR_F_1}
  */
 uint8_t reb_can_send_ecu(uint8_t status)
 {

--- a/test/aux/src/test_ecu_app.c
+++ b/test/aux/src/test_ecu_app.c
@@ -735,8 +735,8 @@ TEST(ecu_app, monitor_tcu_can_send_reb_FAIL)
  *  - Send a message to check communication with REB.
  * Expected:
  *  - Receive from REB a CAN message response with status OK.
- * @requir {SwHLR_F_13}
- * @requir {SwHLR_F_15}
+ * @requir{SwHLR_F_13}
+ * @requir{SwHLR_F_15}
  */
 TEST(ecu_app, check_can_communication_SEND_OK_RECEIVE_OK)
 {
@@ -770,8 +770,8 @@ TEST(ecu_app, check_can_communication_SEND_OK_RECEIVE_OK)
  * Expected:
  *  - not receive from REB a CAN message response with status OK.
  *  - IPC painel show REB FAULT lamp.
- * @requir {SwHLR_F_13}
- * @requir {SwHLR_F_15}
+ * @requir{SwHLR_F_13}
+ * @requir{SwHLR_F_15}
  */
 TEST(ecu_app, check_can_communication_SEND_OK_RECEIVE_FAULT)
 {
@@ -811,8 +811,8 @@ TEST(ecu_app, check_can_communication_SEND_OK_RECEIVE_FAULT)
  * Expected:
  *  - not receive from REB a CAN message response with status OK.
  *  - IPC painel show REB FAULT lamp.
- * @requir {SwHLR_F_13}
- * @requir {SwHLR_F_15}
+ * @requir{SwHLR_F_13}
+ * @requir{SwHLR_F_15}
  */
 TEST(ecu_app, check_can_communication_SEND_CAN_FAIL)
 {

--- a/test/reb/src/test_reb_app.c
+++ b/test/reb/src/test_reb_app.c
@@ -121,6 +121,7 @@ TEST(reb_app, application_init_FAIL)
  *  - Set REB_CANCELED to high.
  * Expected:
  *  - Return SUCCESS (0).
+ * @requir{SwHLR_F_8}
  */
 
 TEST(reb_app, cancel_reb_success)
@@ -140,6 +141,7 @@ TEST(reb_app, cancel_reb_success)
  *  - CAN is unavailable when send cancel reb messsage.
  * Expected:
  *  - Return FAIL (1).
+ * @requir{SwHLR_F_8}
  */
 
 TEST(reb_app, cancel_reb_fail_ipc)
@@ -159,10 +161,15 @@ TEST(reb_app, cancel_reb_fail_ipc)
  *  - Set the activating REB to HIGH.
  * Expected:
  *  - Return SUCCESS (0).
+ * @requir{SwHLR_F_8}
+ * @requir{SwHLR_F_12}
+ * @requir{SwHLR_F_14}
+ * @requir{SwHLR_F_2}
  */
 
 TEST(reb_app, start_reb_success)
 {
+
     flag_reb_canceled = REB_RUNNING;
     mock_can_write_return = SUCCESS;
 
@@ -179,6 +186,10 @@ TEST(reb_app, start_reb_success)
  *  - CAN is unavailable when send start reb messsage.
  * Expected:
  *  - Return FAIL (1).
+ * @requir{SwHLR_F_8}
+ * @requir{SwHLR_F_12}
+ * @requir{SwHLR_F_14}
+ * @requir{SwHLR_F_2}
  */
 
 TEST(reb_app, start_reb_fail_send_can)
@@ -198,6 +209,10 @@ TEST(reb_app, start_reb_fail_send_can)
  *  - Set flag to stop the counting of start reb
  * Expected:
  *  - Return SUCCESS (0).
+ * @requir{SwHLR_F_8}
+ * @requir{SwHLR_F_12}
+ * @requir{SwHLR_F_14}
+ * @requir{SwHLR_F_2}
  */
 
 TEST(reb_app, start_reb_was_canceled_before_timeout)
@@ -283,6 +298,14 @@ TEST(reb_app, read_console_fail)
     TEST_ASSERT_EQUAL_INT(0, status);
 }
 
+/** @brief Tests monitor_read_can() function to SUCCESS.
+ *
+ * Scenario:
+ *  - Reb Activate Pin is set.
+ * Expected:
+ *  - A message CAN should be send.
+ *  @requir{SwHLR_F_3}
+ */
 TEST(reb_app, monitor_read_can_get_handle_tcu)
 {
 
@@ -303,11 +326,11 @@ TEST(reb_app, monitor_read_can_get_handle_tcu)
 /** @brief Tests monitor_read_can() function to FAIL.
  *
  * Scenario:
- *  - Reb Activate Pin is set.
+ *  - CAN is busy.
  * Expected:
- *  - A message CAN should be send.
+ *  - function return FAIL status.
+ *  @requir{SwHLR_F_3}
  */
-
 TEST(reb_app, monitor_read_can_get_handle_tcu_fail)
 {
 
@@ -325,6 +348,14 @@ TEST(reb_app, monitor_read_can_get_handle_tcu_fail)
     TEST_ASSERT_EQUAL(0, flag_status_pin[REB_COUNTDOWN_PIN]);
 }
 
+/** @brief Tests monitor_read_can() function to FAIL.
+ *
+ * Scenario:
+ *  - Can is busy when check can comunication with aux.
+ * Expected:
+ *  - function return FAIL status.
+ *  @requir{SwHLR_F_3}
+ */
 TEST(reb_app, monitor_read_can_check_fail)
 {
 
@@ -342,6 +373,17 @@ TEST(reb_app, monitor_read_can_check_fail)
     TEST_ASSERT_EQUAL(0, flag_status_pin[REB_COUNTDOWN_PIN]);
 }
 
+/** @brief Tests monitor_read_can(), AUX_REB CAN communication.
+ *
+ * Scenario:
+ *  - AUX require response status from REB.
+ * Expected:
+ *  - REB send can message status OK.
+ *  @requir{SwHLR_F_3}
+ *  @requir{SwHLR_F_15}
+ *  @requir{SwHLR_F_13}
+ *  @requir{SwHLR_F_6}
+ */
 TEST(reb_app, monitor_read_can_check_REB_AUX_comunication)
 {
 
@@ -365,6 +407,7 @@ TEST(reb_app, monitor_read_can_check_REB_AUX_comunication)
  *  - With the activation of REB, the countdown should not start.
  * Expected:
  *  - Should not inicialize the counting.
+ *  @requir{SwHLR_F_14}
  */
 
 TEST(reb_app, countdown_reb_not_inicialize)
@@ -388,6 +431,7 @@ TEST(reb_app, countdown_reb_not_inicialize)
  *  - With the activation of REB, the countdown should start.
  * Expected:
  *  - Inicialize the counting.
+ *  @requir{SwHLR_F_14}
  */
 
 TEST(reb_app, countdown_reb_inicialize)

--- a/test/reb/src/test_reb_ecu.c
+++ b/test/reb/src/test_reb_ecu.c
@@ -72,7 +72,10 @@ TEST(reb_ecu, reb_can_send_ipc_status_IPC_REB_CANCEL)
  *  - reb_ecu_id = 1 (engine block)
  * Expected:
  *  - Return SUCCESS (0).
- * @requir{SwHLR_F_12}
+ *  @requir{SwHLR_F_12}
+ *  @requir{SwHLR_F_10}
+ *  @requir{SwHLR_F_2}
+ *  @requir{SwHLR_F_1}
  */
 TEST(reb_ecu, reb_can_send_ecu_status_ECU_REB_START)
 {
@@ -88,7 +91,10 @@ TEST(reb_ecu, reb_can_send_ecu_status_ECU_REB_START)
  *  - reb_ecu_id = 2 (engine unblock)
  * Expected:
  *  - Return SUCCESS (0).
- * @requir{SwHLR_F_12}
+ *  @requir{SwHLR_F_12}
+ *  @requir{SwHLR_F_10}
+ *  @requir{SwHLR_F_2}
+ *  @requir{SwHLR_F_1}
  */
 TEST(reb_ecu, reb_can_send_ecu_status_ECU_REB_CANCEL)
 {
@@ -141,6 +147,8 @@ TEST(reb_ecu, reb_handle_tcu_can_START_REB)
  *  - We force cancel_reb() to fail via mocks.
  * Expected:
  *  - Return FAIL (1).
+ * @requir{SwHLR_F_3}
+ * @requir{SwHLR_F_1}
  */
 TEST(reb_ecu, reb_handle_tcu_can_CANCEL_REB_FAIL)
 {
@@ -160,6 +168,8 @@ TEST(reb_ecu, reb_handle_tcu_can_CANCEL_REB_FAIL)
  *  - We force start_reb() to fail via mocks.
  * Expected:
  *  - Return FAIL (1).
+ * @requir{SwHLR_F_3}
+ * @requir{SwHLR_F_1}
  */
 TEST(reb_ecu, reb_handle_tcu_can_START_REB_FAIL)
 {
@@ -179,6 +189,10 @@ TEST(reb_ecu, reb_handle_tcu_can_START_REB_FAIL)
  *  - We force can_send_vcan0() to fail via mocks (returning -1).
  * Expected:
  *  - Return FAIL (1).
+ *  @requir{SwHLR_F_12}
+ *  @requir{SwHLR_F_10}
+ *  @requir{SwHLR_F_2}
+ *  @requir{SwHLR_F_1}
  */
 TEST(reb_ecu, reb_can_send_ecu_CAN_SEND_VCAN_FAIL)
 {
@@ -196,6 +210,7 @@ TEST(reb_ecu, reb_can_send_ecu_CAN_SEND_VCAN_FAIL)
  *  - We force can_send_vcan0() to fail via mocks (returning -1).
  * Expected:
  *  - Return FAIL (1).
+ *  @requir{SwHLR_F_8}
  */
 TEST(reb_ecu, reb_can_send_ipc_CAN_SEND_VCAN_FAIL)
 {


### PR DESCRIPTION
…comments in some functions

Inserindo comentários faltantes no APP/reb, inserindo também requisitos que não estava presente em algumas funções, e correções de formatação de comentários passando @requir {...} para @requir{...}, (sem espaços).